### PR TITLE
handle empty text elements

### DIFF
--- a/lib/react-d3/extractData.js
+++ b/lib/react-d3/extractData.js
@@ -45,7 +45,7 @@ module.exports = (nodes) => {
     if(output.props.style) output.props.style = getStyles(output.props.style);
 
     // Special case for text tags
-    if(output.tag === 'text') output.props.textContent = obj.childNodes[0].data;
+    if(output.tag === 'text') output.props.textContent = obj.childNodes.length ? obj.childNodes[0].data : '';
 
     // output.props['react-d3-id'] = output.tag + '.' + counter + '.' + i;\
     if(!obj['data-react-d3-id']) {


### PR DESCRIPTION
Currently an exception is thrown if there are any `text` elements with no content (`<text></text>`) since `obj.childNodes[0]` is `undefined`.