### PR TITLE
bug about data-react-d3-id is fixed

### DIFF
--- a/lib/react-d3/extractData.js
+++ b/lib/react-d3/extractData.js
@@ -26,9 +26,10 @@ module.exports = (nodes) => {
 
     //HTML tag name ...div, g, circle, etc...
     output.tag = obj.localName;
+    const sameTagIndex = i + document.getElementsByTagName(obj.localName).length;
 
     if(!obj['data-react-d3-id']) {
-      nodeId = applyD3ReactId(Array.prototype.slice.call(obj.children), i);
+      nodeId = applyD3ReactId(Array.prototype.slice.call(obj.children), sameTagIndex);
       for(var key in nodeId.state) {
         extractedData.state[key] = nodeId.state[key]
       }
@@ -51,9 +52,9 @@ module.exports = (nodes) => {
 
     // output.props['react-d3-id'] = output.tag + '.' + counter + '.' + i;\
     if(!obj['data-react-d3-id']) {
-      output['data-react-d3-id'] = output.tag + '.' + i + '.' + 0 + '.' + 0;
-      output.props.key = output.tag + '.' + i + '.' + 0 + '.' + 0;
-      extractedData.state[output.tag + '.' + i + '.' + 0 + '.' + 0] = {};
+      output['data-react-d3-id'] = output.tag + '.' + sameTagIndex + '.' + 0 + '.' + 0;
+      output.props.key = output.tag + '.' + sameTagIndex + '.' + 0 + '.' + 0;
+      extractedData.state[output.tag + '.' + sameTagIndex + '.' + 0 + '.' + 0] = {};
     } else {
       output['data-react-d3-id'] = obj['data-react-d3-id'];
       output.props.key = obj['data-react-d3-id'];


### PR DESCRIPTION
if we have multiple same elemets(e.x. rect/svg...), data-react-d3-id are duplicated.
So if we add 'event' (e.x. click, hover...), it is not working correctly.

I changed two points to resolve this problem.
First, I add same element count to index that is defined 'i'.

```
const sameTagIndex = i + document.getElementsByTagName(obj.localName).length;
```

Second, I passed the argumen that is defined 'sameTagIndex'.

```
nodeId = applyD3ReactId(Array.prototype.slice.call(obj.children), sameTagIndex);
```

