### PR TITLE
Ie bug fix

### DIFF
--- a/lib/react-d3/extractData.js
+++ b/lib/react-d3/extractData.js
@@ -29,7 +29,7 @@ module.exports = (nodes) => {
     const sameTagIndex = i + document.getElementsByTagName(obj.localName).length;
     let children = [];
     const childNodes = obj.childNodes;
-    for(var i=0; i < obj.childNodes.length; i++) {
+    for(let i=0; i < obj.childNodes.length; i++) {
       if(childNodes[i].tagName) children.push(childNodes[i]);
     }
 

--- a/lib/react-d3/extractData.js
+++ b/lib/react-d3/extractData.js
@@ -27,14 +27,19 @@ module.exports = (nodes) => {
     //HTML tag name ...div, g, circle, etc...
     output.tag = obj.localName;
     const sameTagIndex = i + document.getElementsByTagName(obj.localName).length;
+    let children = [];
+    const childNodes = obj.childNodes;
+    for(var i=0; i < obj.childNodes.length; i++) {
+      if(childNodes[i].tagName) children.push(childNodes[i]);
+    }
 
     if(!obj['data-react-d3-id']) {
-      nodeId = applyD3ReactId(Array.prototype.slice.call(obj.children), sameTagIndex);
+      nodeId = applyD3ReactId(Array.prototype.slice.call(children), sameTagIndex);
       for(var key in nodeId.state) {
         extractedData.state[key] = nodeId.state[key]
       }
     } else {
-      nodeId.children = obj.children;
+      nodeId.children = children;
     }
     // Create an array for all the child nodes
     output.children = nodeId.children;

--- a/lib/utils/applyD3ReactId.js
+++ b/lib/utils/applyD3ReactId.js
@@ -13,13 +13,13 @@ function applyD3ReactId(children, counter) {
       var currentNode = child['data-react-d3-id'] = id;
       var resultObj = result.state[id] = {};
 
-      if(child.children.length) length = child.children.length;
+      if(child.childNodes.length) length = child.childNodes.length;
       if(d3Attributes.length) d3Attributes.forEach( (key) => { resultObj[key] = child[key]; })
       else  resultObj['__data__'] = null;
       if(count === length) count = 0, parentCount++;
 
-      return child.children.length
-        ? ([].slice.call(child.children).forEach(child => apply([child])))
+      return child.childNodes.length
+        ? ([].slice.call(child.childNodes).forEach(child => apply([child])))
         : []
     });
 


### PR DESCRIPTION
As you know, IE don't support "children" method to svgElement.
http://stackoverflow.com/questions/22498045/svgsvgelement-children-not-working-in-ie11

So I replace them to "childNodes" to support IE.

(Actually when we use tspan like ```<text><tspan>test</tspan></text>``` in IE browser, It doesn't do exactlly. So I'll fix that bug next time.)

Please check it. thanks.