### PR TITLE
allow text inside svg title tags

### DIFF
--- a/lib/react-d3/extractData.js
+++ b/lib/react-d3/extractData.js
@@ -50,8 +50,8 @@ module.exports = (nodes) => {
     // If styles exits convert the CSSStyleDeclaration into react friendly syntax-
     if(output.props.style) output.props.style = getStyles(output.props.style);
 
-    // Special case for text and tspan tags
-    if(output.tag === 'text' || output.tag === 'tspan') {
+    // Special case for text, title and tspan tags
+    if(['text', 'title', 'tspan'].includes(output.tag)) {
       output.props.textContent = obj.childNodes.length ? obj.childNodes[0].data : '';
     }
 


### PR DESCRIPTION
- When rendering data inside SVG with D3 one can add
  tooltips using the 'title' tag
- Right now those title tags are rendered with empty text
  and therefore the tooltip is not displayed
- This fixes that
- Proof of concept:
  ![image](https://user-images.githubusercontent.com/47480384/85064478-3d888780-b171-11ea-8d7e-dae51d1b794b.png)
- Before:
  ![image](https://user-images.githubusercontent.com/47480384/85064355-15008d80-b171-11ea-8401-36f0eadad6b1.png)
- Now:
  ![image](https://user-images.githubusercontent.com/47480384/85064192-cb17a780-b170-11ea-8b34-283b88e1595f.png)
  ![image](https://user-images.githubusercontent.com/47480384/85064111-b4715080-b170-11ea-9b24-b30e307c907d.png)
- It would be very awesome if there is an official release to NPM so I can upgrade my dependency and use this changes